### PR TITLE
changed autocomplete to exclude empty categories

### DIFF
--- a/category_autocomplete.py
+++ b/category_autocomplete.py
@@ -5,7 +5,7 @@ import re
 import sys
 from language_dict import language_dict
 
-base_url = "w/api.php?action=query&format=json&formatversion=2&list=allcategories&acprefix="
+base_url = "w/api.php?action=query&format=json&formatversion=2&list=allcategories&acmin=1&acprefix="
 #url_example = https://en.wikipedia.org/w/api.php?action=query&format=json&list=search&srsearch=life%science%data
 
 ###############

--- a/zimmerbot.py
+++ b/zimmerbot.py
@@ -10,7 +10,7 @@ def main(method, query, language_code, filter_method, limit, stub="include"):
     # Process script arguments
     # For now, we only support limiting by number of articles, not total package size
     
-    #limit = max(min(int(limit), 500), 1)
+    limit = max(min(int(limit), 500), 1)
 
     # article_dictionaries is a list of dictionaries
     if method == "individual":


### PR DESCRIPTION
Small change to call for Wikipedia API for category autocomplete (now only includes categories with 1 or more entries). Also, noticed that requesting articles was breaking for me without type conversion, so uncommented line within zimmerbot.py.